### PR TITLE
Add United Kingdom (Great Britain/GBR)

### DIFF
--- a/countries/gbr/gbr.json
+++ b/countries/gbr/gbr.json
@@ -1,0 +1,15 @@
+{
+  "resources": [
+    {
+      "name": "Coronavirus (COVID-19)",
+      "link": "https://www.gov.uk/coronavirus",
+      "organization": "UK Government"
+    },
+    {
+      "name": "Coronavirus (COVID-19) NHS Advice",
+      "link": "https://www.nhs.uk/conditions/coronavirus-covid-19/",
+      "organization": "NHS"
+    }
+  ],
+  "twitterFeed": "phe_uk"
+}


### PR DESCRIPTION
Add country and data sources for United Kingdom/Great Britain

Links to UK Government official website for Coronavirus, and official NHS advice.

Twitter feed links to `@phe_uk`, or Public Health England, which has Coronavirus updates.