### PR TITLE
Add data sources for Switzerland and the canton of Neuchâtel

### DIFF
--- a/countries/che/che.json
+++ b/countries/che/che.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "name": "New coronavirus",
+      "link": "https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov.html",
+      "organization": "Federal Office of Public Health"
+    }
+  ],
+  "twitterFeed": "BAG_OFSP_UFSP"
+}

--- a/countries/che/regions/neuchatel.json
+++ b/countries/che/regions/neuchatel.json
@@ -5,9 +5,11 @@
       "link": "https://www.ne.ch/autorites/DFS/SCSP/medecin-cantonal/maladies-vaccinations/Pages/Coronavirus.aspx",
       "organization": "République et canton de Neuchâtel"
     },
+    {
       "name": "Canton de Neuchâtel Twitter Feed",
       "link": "https://twitter.com/Etat_Neuchatel",
       "organization": "Canton de Neuchâtel"
+    }
   ],
   "twitterFeed": "Etat_Neuchatel"
 }

--- a/countries/che/regions/neuchatel.json
+++ b/countries/che/regions/neuchatel.json
@@ -1,0 +1,15 @@
+{
+  "resources": [
+    {
+      "name": "[name of the resource, (Example — Coronavirus (COVID-19) in California)]",
+      "link": "[link to the resource, (Example — https://covid19.ca.gov/)]",
+      "organization": "[name of the organisation that published the resource, (Example — California State Government)]"
+    },
+    {
+      "name": "Coronavirus COVID-19 - République et canton de Neuchâtel",
+      "link": "https://www.ne.ch/autorites/DFS/SCSP/medecin-cantonal/maladies-vaccinations/Pages/Coronavirus.aspx",
+      "organization": "République et canton de Neuchâtel"
+    }
+  ],
+  "twitterFeed": "Etat_Neuchatel"
+}

--- a/countries/che/regions/neuchatel.json
+++ b/countries/che/regions/neuchatel.json
@@ -1,15 +1,13 @@
 {
   "resources": [
     {
-      "name": "[name of the resource, (Example — Coronavirus (COVID-19) in California)]",
-      "link": "[link to the resource, (Example — https://covid19.ca.gov/)]",
-      "organization": "[name of the organisation that published the resource, (Example — California State Government)]"
-    },
-    {
       "name": "Coronavirus COVID-19 - République et canton de Neuchâtel",
       "link": "https://www.ne.ch/autorites/DFS/SCSP/medecin-cantonal/maladies-vaccinations/Pages/Coronavirus.aspx",
       "organization": "République et canton de Neuchâtel"
-    }
+    },
+      "name": "Canton de Neuchâtel Twitter Feed",
+      "link": "https://twitter.com/Etat_Neuchatel",
+      "organization": "Canton de Neuchâtel"
   ],
   "twitterFeed": "Etat_Neuchatel"
 }


### PR DESCRIPTION
This adds a link for Switzerland, and one for Neuchâtel canton.