### PR TITLE
Added NYC Health Daily Data feeds.

### DIFF
--- a/countries/usa/regions/ny.json
+++ b/countries/usa/regions/ny.json
@@ -14,6 +14,31 @@
       "name": "Office of the Governor of New York Facebook",
       "link": "https://www.facebook.com/GovernorAndrewCuomo",
       "organization": "Office of the Governor of New York"
+    },
+    {
+      "name": "Total Cases — COVID-19 Daily Data Summary",
+      "link": "https://www1.nyc.gov/assets/doh/downloads/pdf/imm/covid-19-daily-data-summary.pdf",
+      "organization": "New York City Department of Health"
+    },
+    {
+      "name": " Deaths — COVID-19 Daily Data Summary",
+      "link": "https://www1.nyc.gov/assets/doh/downloads/pdf/imm/covid-19-daily-data-summary-deaths.pdf",
+      "organization": "New York City Department of Health"
+    },
+    {
+      "name": "Hospitalizations — COVID-19 Daily Data Summary",
+      "link": "https://www1.nyc.gov/assets/doh/downloads/pdf/imm/covid-19-daily-data-summary-hospitalizations.pdf",
+      "organization": "New York City Department of Health"
+    },
+    {
+      "name": "Surveillance Data (Emergency Department Visits)",
+      "link": "https://www1.nyc.gov/assets/doh/downloads/pdf/imm/covid-19-syndromic-surveillance.pdf",
+      "organization": "NYC Emergency Department"
+    },
+    {
+      "name": "Percent of Patients Testing Positive by Neighborhood in NYC",
+      "link": "https://www1.nyc.gov/assets/doh/downloads/pdf/imm/covid-19-data-map.pdf",
+      "organization": "United Hospital Fund / NYC Health"
     }
   ]
 }


### PR DESCRIPTION
NYC Health provides PDFs of total cases, deaths, hospitalizations, and more — updated daily.